### PR TITLE
To work with zimme:iron-router-active

### DIFF
--- a/client/views/header.html
+++ b/client/views/header.html
@@ -34,8 +34,8 @@
         {{/if}}
 
         <ul class="nav navbar-nav navbar-right">
-          <li class="{{ isActiveRoute 'home' }}"><a href="{{ pathFor 'home' }}"><i class="fa fa-home"></i> Home</a></li>
-          <li class="{{ isActivePath 'dashboard' }}"><a href="{{ pathFor 'dashboard' }}"><i class="fa fa-gear"></i> Dashboard</a></li>
+          <li class="{{ isActiveRoute regex='home' }}"><a href="{{ pathFor 'home' }}"><i class="fa fa-home"></i> Home</a></li>
+          <li class="{{ isActivePath regex='dashboard' }}"><a href="{{ pathFor 'dashboard' }}"><i class="fa fa-gear"></i> Dashboard</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
zimme:iron-router-active isActiveRoute and isActivePath requires a key/value instead of just one parameter.
