### PR TITLE
update to momentjs:moment Official package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -12,7 +12,7 @@ zimme:iron-router-active
 cmather:handlebars-server@0.2.0
 dburles:collection-helpers
 reywood:publish-composite
-mrt:moment
+momentjs:moment
 mrt:underscore-string-latest
 matb33:collection-hooks
 dburles:factory


### PR DESCRIPTION
Update to official meteor momentjs package.
This fix some issues relate to i18n.

Now you can add locales easily like:

`meteor add rzymek:moment-locale-es`


`rzymek:moment-locale-es` package depend on `momentjs:moment`.



