### PR TITLE
Remove DEPRECATED AccountsTemplates.ensureSignedIn.call and Add Router e...

### DIFF
--- a/both/controllers/dashboard.js
+++ b/both/controllers/dashboard.js
@@ -5,9 +5,6 @@ DashboardController = AppController.extend({
   data: {
     items: Items.find({})
   },
-  onBeforeAction: function (pause) {
-    AccountsTemplates.ensureSignedIn.call(this, pause);
-  },
   onAfterAction: function () {
     Meta.setTitle('Dashboard');
   }

--- a/both/router/routes.js
+++ b/both/router/routes.js
@@ -2,4 +2,10 @@ Router.route('/', {
   name: 'home'
 });
 
-Router.route('/dashboard');
+Router.route('/dashboard', {
+  name: 'dashboard'
+});
+
+Router.plugin('ensureSignedIn', {
+  only: ['dashboard']
+});


### PR DESCRIPTION
Remove DEPRECATED `AccountsTemplates.ensureSignedIn.call` on `DashboardController`.
Add new Router plugin `ensureSignedIn` from `useraccounts:core` package.
A more clean aproach to enforce content protection.
