### PR TITLE
Replace old mrt package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -13,7 +13,7 @@ cmather:handlebars-server@0.2.0
 dburles:collection-helpers
 reywood:publish-composite
 momentjs:moment
-mrt:underscore-string-latest
+underscorestring:underscore.string
 matb33:collection-hooks
 dburles:factory
 anti:fake


### PR DESCRIPTION
Replaced the mrt:underscore-string-latest with the new underscorestring:underscore.string package. 

See http://epeli.github.io/underscore.string/