### PR TITLE
changed global reference for underscore.string

### DIFF
--- a/client/helpers/stringHelpers.js
+++ b/client/helpers/stringHelpers.js
@@ -1,4 +1,4 @@
 Template.registerHelper('truncate', function(string, length) {
-  var cleanString = _(string).stripTags();
-  return _(cleanString).truncate(length);
+  var cleanString = s(string).stripTags();
+  return s(cleanString).truncate(length);
 });


### PR DESCRIPTION
Global var is "s", not "_"

http://epeli.github.io/underscore.string/#in-meteor